### PR TITLE
Clean-up to reduce pylint info / warnings

### DIFF
--- a/marbl_diags/analysis_ops.py
+++ b/marbl_diags/analysis_ops.py
@@ -171,7 +171,7 @@ def _plot_climo(AnalysisElement, valid_time_dims):
                                                                     extend=AnalysisElement.get_var(v)['contours']['extend'],
                                                                     cmap=AnalysisElement.get_var(v)['contours']['cmap'],
                                                                     norm=colors.BoundaryNorm(boundaries=levels, ncolors=256))
-                    cs = AnalysisElement.axs[plot_name][i].contour(cf, transform=ccrs.PlateCarree(),
+                    cs = AnalysisElement.axs[plot_name][i].contour(cf, transform=ccrs.PlateCarree(), # pylint: disable=unused-variable
                                                                    levels=AnalysisElement.get_var(v)['contours']['levels'],
                                                                    extend=AnalysisElement.get_var(v)['contours']['extend'],
                                                                    linewidths=0.5, colors='k')

--- a/marbl_diags/generic_classes.py
+++ b/marbl_diags/generic_classes.py
@@ -24,6 +24,12 @@ class GenericDataSource(object): # pylint: disable=useless-object-inheritance
     # PUBLIC ROUTINES #
     ###################
 
+    def is_var(self, var_name):
+        return var_name in self._var_dict
+
+    def get_var(self, var_name):
+        return self._var_dict[var_name]
+
     def compute_mon_climatology(self):
         """ Compute a monthly climatology """
 
@@ -151,3 +157,9 @@ class GenericAnalysisElement(object):
         # (4) Set up objects for plotting
         self.fig = dict()
         self.axs = dict()
+
+    def get_config(self, key):
+        return self._global_config[key]
+
+    def get_var(self, var_name):
+        return self._var_dict[var_name]


### PR DESCRIPTION
1. spaces after commas
2. introduced some public routines to return private data from generic classes
   - get_var(var_name) returns _var_dict[var_name]
     * GenericAnalysisElement and GenericDataSource
   - get_config(key) returns _global_config[key]
     * GenericAnalysisElement only
   - is_var(var_name) returns (var_name in var_dict)
     * GenericDataSource only
3. Disabled some pylint warnings to reduce the noise